### PR TITLE
feat(message-converter): add support for customer message converter

### DIFF
--- a/Rebus.GoogleCloudPubSub.Tests/Conversions/ConvertingFromRebusTransportToGoogleTransportAndBack.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Conversions/ConvertingFromRebusTransportToGoogleTransportAndBack.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Google.Cloud.PubSub.V1;
 using NUnit.Framework;
+using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Messages;
 
 namespace Rebus.GoogleCloudPubSub.Tests.Conversions
@@ -16,9 +17,11 @@ namespace Rebus.GoogleCloudPubSub.Tests.Conversions
             var theHeaderContent = new Dictionary<string, string>() { { "xheader1", "header1content" }, { "xheader2", "header2content" }, { Headers.MessageId, Guid.NewGuid().ToString() } };
             var rebusTransportMessage = new TransportMessage(theHeaderContent, System.Text.Encoding.UTF8.GetBytes(theBodyContent));
 
-            var googlePubSubMessage = rebusTransportMessage.ToPubSubMessage();
-            var received = new ReceivedMessage() { AckId = "ackid", DeliveryAttempt = 1, Message = googlePubSubMessage };
-            var final = received.ToRebusTransportMessage();
+            var messageConverter = new DefaultMessageConverter();
+            
+            var googlePubSubMessage = messageConverter.ToPubsub(rebusTransportMessage);
+            var received = new ReceivedMessage { AckId = "ackid", DeliveryAttempt = 1, Message = googlePubSubMessage };
+            var final = messageConverter.ToTransport(received.Message);
 
             Assert.AreEqual(theBodyContent, System.Text.Encoding.UTF8.GetString(final.Body));
             CollectionAssert.AreEqual(theHeaderContent, final.Headers);

--- a/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubBusFactory.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubBusFactory.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
+using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Tests.Contracts.Transports;
 
@@ -40,7 +41,7 @@ namespace Rebus.GoogleCloudPubSub.Tests.Factory
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
 
-            using var transport = new GoogleCloudPubSubTransport(_projectId, queueName, consoleLoggerFactory);
+            using var transport = new GoogleCloudPubSubTransport(_projectId, queueName, consoleLoggerFactory, new DefaultMessageConverter());
 
             transport.PurgeQueueAsync()
                 .GetAwaiter()

--- a/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Tests.Contracts.Transports;
 using Rebus.Transport;
@@ -12,7 +13,7 @@ namespace Rebus.GoogleCloudPubSub.Tests.Factory
         public ITransport CreateOneWayClient()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver, consoleLoggerFactory);
+            var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver, consoleLoggerFactory, new DefaultMessageConverter());
 
             _disposables.Push(transport);
 
@@ -22,7 +23,7 @@ namespace Rebus.GoogleCloudPubSub.Tests.Factory
         public ITransport Create(string inputQueueAddress)
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueueAddress, consoleLoggerFactory);
+            var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueueAddress, consoleLoggerFactory, new DefaultMessageConverter());
             transport.PurgeQueueAsync().ConfigureAwait(false);
             transport.Initialize();
 

--- a/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSub/Messages/DefaultMessageConverterTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSub/Messages/DefaultMessageConverterTest.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using NUnit.Framework;
+using Rebus.GoogleCloudPubSub.Messages;
+using Rebus.Messages;
+
+namespace Rebus.GoogleCloudPubSub.Tests.GoogleCloudPubSub.Messages;
+
+[TestFixture]
+[TestOf(typeof(DefaultMessageConverter))]
+public class DefaultMessageConverterTest
+{
+    [SetUp]
+    public void SetUp()
+    {
+        _converter = new DefaultMessageConverter();
+    }
+
+    private DefaultMessageConverter _converter;
+
+    [Test]
+    public void ToTransport_ConvertsPubsubMessageToTransportMessage()
+    {
+        // Arrange
+        var pubsubMessage = new PubsubMessage
+        {
+            Data = ByteString.CopyFromUtf8("Test message"),
+            MessageId = "test-message-id",
+            PublishTime = Timestamp.FromDateTime(DateTime.UtcNow),
+            Attributes =
+            {
+                { "ContentType", "text/plain" },
+                { "CorrelationId", "12345" },
+                { "CustomHeader", "CustomValue" }
+            },
+            OrderingKey = 12345.ToString()
+        };
+
+        // Act
+        var transportMessage = _converter.ToTransport(pubsubMessage);
+
+        // Assert
+        Assert.NotNull(transportMessage);
+        Assert.AreEqual(pubsubMessage.Data.ToByteArray(), transportMessage.Body);
+        Assert.AreEqual(pubsubMessage.MessageId, transportMessage.Headers[Headers.MessageId]);
+        Assert.AreEqual(pubsubMessage.OrderingKey, transportMessage.Headers[ExtraHeaders.OrderingKey]);
+        Assert.AreEqual(pubsubMessage.PublishTime.ToDateTime().ToString("o", CultureInfo.InvariantCulture),
+            transportMessage.Headers[Headers.SentTime]);
+        Assert.AreEqual("text/plain", transportMessage.Headers[Headers.ContentType]);
+        Assert.AreEqual("12345", transportMessage.Headers[Headers.CorrelationId]);
+        Assert.AreEqual("CustomValue", transportMessage.Headers["CustomHeader"]);
+    }
+
+    [Test]
+    public void ToPubsub_ConvertsTransportMessageToPubsubMessage()
+    {
+        // Arrange
+        var transportMessage = new TransportMessage(new Dictionary<string, string>
+        {
+            { Headers.MessageId, "test-message-id" },
+            { Headers.ContentType, "text/plain" },
+            { ExtraHeaders.OrderingKey, "12345" },
+            { Headers.CorrelationId, "12345" },
+            { "CustomHeader", "CustomValue" },
+            { Headers.SentTime, DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture) }
+        }, ByteString.CopyFromUtf8("Test message").ToByteArray());
+
+        // Act
+        var pubsubMessage = _converter.ToPubsub(transportMessage);
+
+        // Assert
+        Assert.NotNull(pubsubMessage);
+        Assert.AreEqual(transportMessage.Body, pubsubMessage.Data.ToByteArray());
+        Assert.AreEqual(transportMessage.Headers[Headers.MessageId], pubsubMessage.MessageId);
+        Assert.AreEqual(transportMessage.Headers[ExtraHeaders.OrderingKey],
+            pubsubMessage.OrderingKey);
+        Assert.AreEqual(transportMessage.Headers[Headers.SentTime],
+            pubsubMessage.PublishTime.ToDateTime().ToString("o", CultureInfo.InvariantCulture));
+        Assert.AreEqual(transportMessage.Headers[Headers.ContentType],
+            pubsubMessage.Attributes[ExtraHeaders.ContentType]);
+        Assert.AreEqual(transportMessage.Headers[Headers.CorrelationId],
+            pubsubMessage.Attributes[ExtraHeaders.CorrelationId]);
+        Assert.AreEqual("CustomValue", pubsubMessage.Attributes["CustomHeader"]);
+    }
+
+    [Test]
+    public void ToTransport_MessageWithoutHeaders_ConvertsSuccessfully()
+    {
+        // Arrange
+        var pubsubMessage = new PubsubMessage
+        {
+            Data = ByteString.CopyFromUtf8("Test message"),
+            MessageId = "test-message-id",
+            PublishTime = Timestamp.FromDateTime(DateTime.UtcNow)
+        };
+
+        // Act
+        var transportMessage = _converter.ToTransport(pubsubMessage);
+
+        // Assert
+        Assert.NotNull(transportMessage);
+        Assert.AreEqual(pubsubMessage.Data.ToByteArray(), transportMessage.Body);
+        Assert.AreEqual(pubsubMessage.MessageId, transportMessage.Headers[Headers.MessageId]);
+        Assert.AreEqual(pubsubMessage.PublishTime.ToDateTime().ToString("o", CultureInfo.InvariantCulture),
+            transportMessage.Headers[Headers.SentTime]);
+        Assert.False(transportMessage.Headers.ContainsKey(Headers.ContentType));
+        Assert.False(transportMessage.Headers.ContainsKey(Headers.CorrelationId));
+    }
+
+    [Test]
+    public void ToPubsub_MessageWithoutHeaders_ConvertsSuccessfully()
+    {
+        // Arrange
+        var body = ByteString.CopyFromUtf8("Test message").ToByteArray();
+        var transportMessage = new TransportMessage(new Dictionary<string, string>(), body);
+
+        // Act
+        var pubsubMessage = _converter.ToPubsub(transportMessage);
+
+        // Assert
+        Assert.NotNull(pubsubMessage);
+        Assert.AreEqual(transportMessage.Body, pubsubMessage.Data.ToByteArray());
+        Assert.False(pubsubMessage.Attributes.ContainsKey(Headers.MessageId));
+        Assert.False(pubsubMessage.Attributes.ContainsKey(Headers.SentTime));
+        Assert.False(pubsubMessage.Attributes.ContainsKey(ExtraHeaders.ContentType));
+        Assert.False(pubsubMessage.Attributes.ContainsKey(ExtraHeaders.CorrelationId));
+        Assert.False(pubsubMessage.Attributes.ContainsKey(Headers.SentTime));
+    }
+}

--- a/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
+++ b/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.8.0" />
+    <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.16.0" />
     <PackageReference Include="microsoft.net.test.sdk" Version="17.8.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="nunit3testadapter" Version="4.5.0" />

--- a/Rebus.GoogleCloudPubSub.sln
+++ b/Rebus.GoogleCloudPubSub.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.md = LICENSE.md
 		README.md = README.md
+		docker-compose.yaml = docker-compose.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.GoogleCloudPubSub", "Rebus.GoogleCloudPubSub\Rebus.GoogleCloudPubSub.csproj", "{1DDC598A-1C02-4719-ADC9-25EDEC42B667}"

--- a/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
+++ b/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
@@ -1,23 +1,31 @@
 ﻿using System;
 using Rebus.GoogleCloudPubSub;
+using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Transport;
 
-namespace Rebus.Config
-{
-    public static class GoogleCloudPubSubTransportConfigurationExtensions
-    {
-        public static void UsePubSub(this StandardConfigurer<ITransport> configurer, string projectId, string inputQueueName)
-        {
-            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-            if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
-            configurer.Register(c => new GoogleCloudPubSubTransport(projectId, inputQueueName, c.Get<IRebusLoggerFactory>()));
-        }
+namespace Rebus.Config;
 
-        public static void UsePubSubAsOneWayClient(this StandardConfigurer<ITransport> configurer, string projectId)
-        {
-            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-            configurer.Register(c => new GoogleCloudPubSubTransport(projectId, null, c.Get<IRebusLoggerFactory>()));
-        }
+public static class GoogleCloudPubSubTransportConfigurationExtensions
+{
+    public static void UsePubSub(this StandardConfigurer<ITransport> configurer, string projectId,
+        string inputQueueName)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
+        configurer.Register(c => new GoogleCloudPubSubTransport(projectId, inputQueueName,
+            c.Get<IRebusLoggerFactory>(), c.Get<IMessageConverter>()));
+        
+        configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
+    }
+
+    public static void UsePubSubAsOneWayClient(this StandardConfigurer<ITransport> configurer, string projectId)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        configurer.Register(c =>
+            new GoogleCloudPubSubTransport(projectId, null, c.Get<IRebusLoggerFactory>(),
+                c.Get<IMessageConverter>()));
+        
+        configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
     }
 }

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/GoogleCloudPubSubTransport.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/GoogleCloudPubSubTransport.cs
@@ -10,237 +10,244 @@ using Google.Cloud.PubSub.V1;
 using Grpc.Core;
 using Rebus.Bus;
 using Rebus.Exceptions;
+using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Messages;
 using Rebus.Transport;
 
-namespace Rebus.GoogleCloudPubSub
+namespace Rebus.GoogleCloudPubSub;
+
+public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable, IDisposable
 {
-    public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable, IDisposable
+    private readonly ConcurrentDictionary<string, Lazy<Task<PublisherClient>>> _clients = new();
+    private readonly string _inputQueueName;
+    private readonly IMessageConverter _messageConverter;
+    private readonly string _projectId;
+    protected readonly ILog Log;
+
+    private TopicName _inputTopic;
+    private SubscriberServiceApiClient _subscriberClient;
+    private SubscriptionName _subscriptionName;
+
+
+    public GoogleCloudPubSubTransport(string projectId, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory,
+        IMessageConverter messageConverter) : base(inputQueueName)
     {
-        private readonly ConcurrentDictionary<string, Lazy<Task<PublisherClient>>> _clients = new();
-        private readonly string _projectId;
-        private readonly string _inputQueueName;
+        _projectId = projectId ?? throw new ArgumentNullException(nameof(projectId));
+        _inputQueueName = inputQueueName;
+        if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+        Log = rebusLoggerFactory.GetLogger<GoogleCloudPubSubTransport>();
+        _messageConverter = messageConverter ?? throw new ArgumentNullException(nameof(messageConverter));
+    }
 
-        private TopicName _inputTopic;
-        private SubscriberServiceApiClient _subscriberClient;
-        private SubscriptionName _subscriptionName;
-        protected readonly ILog Log;
+    public void Dispose()
+    {
+    }
 
-        public GoogleCloudPubSubTransport(string projectId, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory) : base(inputQueueName)
+    public void Initialize()
+    {
+        if (!string.IsNullOrEmpty(_inputQueueName))
         {
-            _projectId = projectId ?? throw new ArgumentNullException(nameof(projectId));
-            _inputQueueName = inputQueueName;
-            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
-            Log = rebusLoggerFactory.GetLogger<GoogleCloudPubSubTransport>();
+            _inputTopic = new TopicName(_projectId, _inputQueueName);
+            CreateQueue(_inputQueueName);
+            AsyncHelpers.RunSync(CreateSubscriptionAsync);
+        }
+    }
+
+    private async Task<PublisherServiceApiClient> GetPublisherServiceApiClientAsync()
+    {
+        return await new PublisherServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+        }.BuildAsync();
+    }
+
+    public override void CreateQueue(string address)
+    {
+        var service = GetPublisherServiceApiClientAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        var topic = new TopicName(_projectId, address);
+        try
+        {
+            service.GetTopic(topic);
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            service.CreateTopic(topic);
+            Log.Info("Created topic {topic} ", _inputTopic);
+        }
+    }
+
+    public async Task PurgeQueueAsync()
+    {
+        var topic = new TopicName(_projectId, _inputQueueName);
+        try
+        {
+            var service = await GetPublisherServiceApiClientAsync();
+            await service.DeleteTopicAsync(topic);
+            Log.Info("Purged topic {topic} by deleting it", topic.ToString());
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            Log.Warn("Tried purging topic {topic} by deleting it, but it could not be found", topic.ToString());
         }
 
-        private async Task<PublisherServiceApiClient> GetPublisherServiceApiClientAsync()
+        _subscriptionName = SubscriptionName.FromProjectSubscription(_projectId, _inputQueueName);
+        try
         {
-            return await new PublisherServiceApiClientBuilder()
-            {
-                EmulatorDetection = EmulatorDetection.EmulatorOrProduction
-            }.BuildAsync();
-        }
-
-        public override void CreateQueue(string address)
-        {
-            var service = GetPublisherServiceApiClientAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            var topic = new TopicName(_projectId, address);
-            try
-            {
-                service.GetTopic(topic);
-            }
-            catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
-            {
-                service.CreateTopic(topic);
-                Log.Info("Created topic {topic} ", _inputTopic);
-            }
-        }
-
-        public void Initialize()
-        {
-            if (!string.IsNullOrEmpty(_inputQueueName))
-            {
-                _inputTopic = new TopicName(_projectId, _inputQueueName);
-                CreateQueue(_inputQueueName);
-                AsyncHelpers.RunSync(CreateSubscriptionAsync);
-            }
-        }
-
-        public async Task PurgeQueueAsync()
-        {
-            var topic = new TopicName(_projectId, _inputQueueName);
-            try
-            {
-                var service = await GetPublisherServiceApiClientAsync();
-                await service.DeleteTopicAsync(topic);
-                Log.Info("Purged topic {topic} by deleting it", topic.ToString());
-            }
-            catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
-            {
-                Log.Warn("Tried purging topic {topic} by deleting it, but it could not be found", topic.ToString());
-            }
-
-            _subscriptionName = SubscriptionName.FromProjectSubscription(_projectId, _inputQueueName);
-            try
-            {
-                _subscriberClient = await GetSubscriberServiceApiClientAsync();
-                await _subscriberClient.DeleteSubscriptionAsync(_subscriptionName);
-                Log.Info("Purged subscription {subscriptionname} by deleting it", _subscriptionName.ToString());
-            }
-            catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
-            {
-                Log.Info("Tried purging subscription {subscriptionname} by deleting it, but it could not be found", _subscriptionName.ToString());
-            }
-        }
-
-        private async Task<SubscriberServiceApiClient> GetSubscriberServiceApiClientAsync()
-        {
-            return await new SubscriberServiceApiClientBuilder()
-            {
-                EmulatorDetection = EmulatorDetection.EmulatorOrProduction
-            }.BuildAsync();
-        }
-
-        private async Task CreateSubscriptionAsync()
-        {
-            _subscriptionName = SubscriptionName.FromProjectSubscription(_projectId, _inputQueueName);
-
             _subscriberClient = await GetSubscriberServiceApiClientAsync();
-
-            try
-            {
-                await _subscriberClient.GetSubscriptionAsync(_subscriptionName);
-            }
-            catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
-            {
-                int retries = 0;
-                var maxRetries = 10;
-                while (retries < maxRetries)
-                {
-                    try
-                    {
-                        await _subscriberClient.CreateSubscriptionAsync(_subscriptionName.ToString(), _inputTopic.ToString(), null, 30, null);
-                        //wait after subscription is created - because some delay on google's side
-                        await Task.Delay(5000);
-                        Log.Info("Created subscription {sub} for topic {topic}", _subscriptionName.ToString(), _inputTopic.ToString());
-                        break;
-                    }
-                    catch (RpcException ex1) when (ex1.StatusCode == StatusCode.NotFound)
-                    {
-                        Log.Warn("Failed creating subscription {sub} for topic {topic} {times}", _subscriptionName.ToString(), _inputTopic.ToString(), retries + 1);
-                        retries++;
-                        if (retries == maxRetries)
-                            throw new RebusApplicationException($"Could not create subscription topic {_inputTopic}");
-                        await Task.Delay(1000 * retries);
-                    }
-                }
-            }
+            await _subscriberClient.DeleteSubscriptionAsync(_subscriptionName);
+            Log.Info("Purged subscription {subscriptionname} by deleting it", _subscriptionName.ToString());
         }
-
-        public override async Task<TransportMessage> Receive(ITransactionContext context, CancellationToken cancellationToken)
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
         {
-            if (_subscriberClient == null) return null;
-
-            ReceivedMessage receivedMessage = null;
-            try
-            {
-                var response = await _subscriberClient.PullAsync(
-                    new PullRequest() { SubscriptionAsSubscriptionName = _subscriptionName, MaxMessages = 1 },
-                    CallSettings.FromCancellationToken(cancellationToken)
-                );
-                receivedMessage = response.ReceivedMessages.FirstOrDefault();
-            }
-            catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.Unavailable)
-            {
-                throw new RebusApplicationException(ex, "GooglePubSub UNAVAILABLE due to too many concurrent pull requests pending for the given subscription");
-
-            }
-            catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
-            {
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    //Rebus has not ordered this cancellation - therefore throwing
-                    throw new RebusApplicationException(ex, "Cancelled when fetching messages from GooglePubSub");
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new RebusApplicationException(ex, "Failed when fetching messages from GooglePubSub");
-            }
-
-
-            if (receivedMessage == null) return null;
-
-            var receivedTransportMessage = receivedMessage.ToRebusTransportMessage();
-
-            var utcNow = DateTimeOffset.UtcNow;
-            if (receivedTransportMessage.IsExpired(utcNow))
-            {
-                Log.Debug($"Discarded message {string.Join(",", receivedTransportMessage.Headers.Select(a => a.Key + " : " + a.Value).ToArray())} because message expired {receivedTransportMessage.AbsoluteExpiryTimeUtc()} which is lesser than current time {utcNow}");
-                return null;
-            }
-
-
-            context.OnAck(async ctx =>
-            {
-                await _subscriberClient.AcknowledgeAsync(_subscriptionName, new[] { receivedMessage.AckId });
-            });
-
-            context.OnNack(async ctx =>
-            {
-                await _subscriberClient.ModifyAckDeadlineAsync(_subscriptionName, new[] { receivedMessage.AckId }, 0);
-            });
-
-            return receivedTransportMessage;
+            Log.Info("Tried purging subscription {subscriptionname} by deleting it, but it could not be found",
+                _subscriptionName.ToString());
         }
+    }
 
-        protected override async Task SendOutgoingMessages(IEnumerable<OutgoingTransportMessage> outgoingMessages, ITransactionContext context)
+    private async Task<SubscriberServiceApiClient> GetSubscriberServiceApiClientAsync()
+    {
+        return await new SubscriberServiceApiClientBuilder
         {
-            var messagesByDestinationQueues = outgoingMessages.GroupBy(m => m.DestinationAddress);
+            EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+        }.BuildAsync();
+    }
 
-            async Task SendMessagesToQueue(string queueName, IEnumerable<OutgoingTransportMessage> messages)
-            {
-                var publisherClient = await GetPublisherClient(queueName);
+    private async Task CreateSubscriptionAsync()
+    {
+        _subscriptionName = SubscriptionName.FromProjectSubscription(_projectId, _inputQueueName);
 
-                await Task.WhenAll(
-                    messages
-                        .Select(m => m.TransportMessage.ToPubSubMessage())
-                        .Select(publisherClient.PublishAsync)
-                );
-            }
+        _subscriberClient = await GetSubscriberServiceApiClientAsync();
 
-            await Task.WhenAll(messagesByDestinationQueues.Select(g => SendMessagesToQueue(g.Key, g)));
+        try
+        {
+            await _subscriberClient.GetSubscriptionAsync(_subscriptionName);
         }
-
-        async Task<PublisherClient> GetPublisherClient(string queueName)
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
         {
-            async Task<PublisherClient> CreatePublisherClient()
-            {
-                var topicName = TopicName.FromProjectTopic(_projectId, queueName);
+            var retries = 0;
+            var maxRetries = 10;
+            while (retries < maxRetries)
                 try
                 {
-                    return await new PublisherClientBuilder
-                    {
-                        TopicName = topicName,
-                        EmulatorDetection = EmulatorDetection.EmulatorOrProduction,
-                    }.BuildAsync();
+                    await _subscriberClient.CreateSubscriptionAsync(_subscriptionName.ToString(),
+                        _inputTopic.ToString(), null, 30);
+                    //wait after subscription is created - because some delay on google's side
+                    await Task.Delay(5000);
+                    Log.Info("Created subscription {sub} for topic {topic}", _subscriptionName.ToString(),
+                        _inputTopic.ToString());
+                    break;
                 }
-                catch (Exception exception)
+                catch (RpcException ex1) when (ex1.StatusCode == StatusCode.NotFound)
                 {
-                    throw new RebusApplicationException(exception,
-                        $"Could not create publisher client for topic {topicName}");
+                    Log.Warn("Failed creating subscription {sub} for topic {topic} {times}",
+                        _subscriptionName.ToString(), _inputTopic.ToString(), retries + 1);
+                    retries++;
+                    if (retries == maxRetries)
+                        throw new RebusApplicationException($"Could not create subscription topic {_inputTopic}");
+                    await Task.Delay(1000 * retries);
                 }
-            }
-
-            var task = _clients.GetOrAdd(queueName, _ => new Lazy<Task<PublisherClient>>(CreatePublisherClient));
-
-            return await task.Value;
         }
+    }
 
-        public void Dispose()
+    public override async Task<TransportMessage> Receive(ITransactionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (_subscriberClient == null) return null;
+
+        ReceivedMessage receivedMessage = null;
+        try
         {
+            var response = await _subscriberClient.PullAsync(
+                new PullRequest { SubscriptionAsSubscriptionName = _subscriptionName, MaxMessages = 1 },
+                CallSettings.FromCancellationToken(cancellationToken)
+            );
+            receivedMessage = response.ReceivedMessages.FirstOrDefault();
         }
+        catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.Unavailable)
+        {
+            throw new RebusApplicationException(ex,
+                "GooglePubSub UNAVAILABLE due to too many concurrent pull requests pending for the given subscription");
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+        {
+            if (!cancellationToken.IsCancellationRequested)
+                //Rebus has not ordered this cancellation - therefore throwing
+                throw new RebusApplicationException(ex, "Cancelled when fetching messages from GooglePubSub");
+        }
+        catch (Exception ex)
+        {
+            throw new RebusApplicationException(ex, "Failed when fetching messages from GooglePubSub");
+        }
+
+
+        if (receivedMessage == null) return null;
+
+        var receivedTransportMessage = _messageConverter.ToTransport(receivedMessage.Message);
+
+        var utcNow = DateTimeOffset.UtcNow;
+        if (receivedTransportMessage.IsExpired(utcNow))
+        {
+            Log.Debug(
+                $"Discarded message {string.Join(",", receivedTransportMessage.Headers.Select(a => a.Key + " : " + a.Value).ToArray())} because message expired {receivedTransportMessage.AbsoluteExpiryTimeUtc()} which is lesser than current time {utcNow}");
+            return null;
+        }
+
+
+        context.OnAck(async ctx =>
+        {
+            await _subscriberClient.AcknowledgeAsync(_subscriptionName, new[] { receivedMessage.AckId });
+        });
+
+        context.OnNack(async ctx =>
+        {
+            await _subscriberClient.ModifyAckDeadlineAsync(_subscriptionName, new[] { receivedMessage.AckId }, 0);
+        });
+
+        return receivedTransportMessage;
+    }
+
+    protected override async Task SendOutgoingMessages(IEnumerable<OutgoingTransportMessage> outgoingMessages,
+        ITransactionContext context)
+    {
+        var messagesByDestinationQueues = outgoingMessages.GroupBy(m => m.DestinationAddress);
+
+        async Task SendMessagesToQueue(string queueName, IEnumerable<OutgoingTransportMessage> messages)
+        {
+            var publisherClient = await GetPublisherClient(queueName);
+
+            await Task.WhenAll(
+                messages
+                    .Select(m => _messageConverter.ToPubsub(m.TransportMessage))
+                    .Select(publisherClient.PublishAsync)
+            );
+        }
+
+        await Task.WhenAll(messagesByDestinationQueues.Select(g => SendMessagesToQueue(g.Key, g)));
+    }
+
+    private async Task<PublisherClient> GetPublisherClient(string queueName)
+    {
+        async Task<PublisherClient> CreatePublisherClient()
+        {
+            var topicName = TopicName.FromProjectTopic(_projectId, queueName);
+            try
+            {
+                return await new PublisherClientBuilder
+                {
+                    TopicName = topicName,
+                    EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+                }.BuildAsync();
+            }
+            catch (Exception exception)
+            {
+                throw new RebusApplicationException(exception,
+                    $"Could not create publisher client for topic {topicName}");
+            }
+        }
+
+        var task = _clients.GetOrAdd(queueName, _ => new Lazy<Task<PublisherClient>>(CreatePublisherClient));
+
+        return await task.Value;
     }
 }

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/DefaultMessageConverter.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/DefaultMessageConverter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Rebus.Extensions;
+using Rebus.Messages;
+
+namespace Rebus.GoogleCloudPubSub.Messages;
+
+public class DefaultMessageConverter : IMessageConverter
+{
+    public TransportMessage ToTransport(PubsubMessage message)
+    {
+        var attributes = message.Attributes;
+
+        var headers = attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString());
+
+        if (headers.TryGetValue(ExtraHeaders.ContentType, out var contentType))
+            headers[Headers.ContentType] = contentType;
+
+        if (headers.TryGetValue(ExtraHeaders.CorrelationId, out var correlationId))
+            headers[Headers.CorrelationId] = correlationId;
+
+        if (!string.IsNullOrEmpty(message.OrderingKey)) headers[ExtraHeaders.OrderingKey] = message.OrderingKey;
+        
+        if (message.PublishTime is not null)
+        {
+            headers[Headers.SentTime] = message.PublishTime.ToDateTime().ToString("o", CultureInfo.InvariantCulture);
+        }
+
+        if (!string.IsNullOrEmpty(message.MessageId))
+        {
+            headers[Headers.MessageId] = message.MessageId;
+        }
+
+        return new TransportMessage(headers, message.Data.ToByteArray());
+    }
+
+    public PubsubMessage ToPubsub(TransportMessage transportMessage)
+    {
+        var message = new PubsubMessage
+        {
+            Data = ByteString.CopyFrom(transportMessage.Body)
+        };
+
+        var headers = transportMessage.Headers.Clone();
+
+        if (headers.TryGetValue(Headers.MessageId, out var messageId))
+        {
+            message.MessageId = messageId;
+            headers.Remove(Headers.MessageId);
+        }
+
+        if (headers.TryGetValue(Headers.SentTime, out var sentTimeString) &&
+            DateTime.TryParse(sentTimeString, out var sentTime))
+        {
+            headers.Remove(Headers.SentTime);
+            message.PublishTime = Timestamp.FromDateTime(sentTime.ToUniversalTime());
+        }
+
+        if (headers.TryGetValue(ExtraHeaders.OrderingKey, out var orderingKey))
+        {
+            headers.Remove(ExtraHeaders.OrderingKey);
+            message.OrderingKey = orderingKey;
+        }
+
+        if (headers.TryGetValue(Headers.ContentType, out var contentType))
+        {
+            headers.Remove(Headers.ContentType);
+            message.Attributes[ExtraHeaders.ContentType] = contentType;
+        }
+
+        if (headers.TryGetValue(Headers.CorrelationId, out var correlationId))
+        {
+            headers.Remove(Headers.CorrelationId);
+            message.Attributes[ExtraHeaders.CorrelationId] = correlationId;
+        }
+
+        foreach (var kvp in headers) message.Attributes[kvp.Key] = kvp.Value;
+
+        return message;
+    }
+}

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/ExtraHeaders.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/ExtraHeaders.cs
@@ -1,0 +1,8 @@
+namespace Rebus.GoogleCloudPubSub.Messages;
+
+public static class ExtraHeaders
+{
+    public const string CorrelationId = "CorrelationId";
+    public const string ContentType = "ContentType";
+    public const string OrderingKey = "OrderingKey";
+}

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/IMessageConverter.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/Messages/IMessageConverter.cs
@@ -1,0 +1,10 @@
+using Google.Cloud.PubSub.V1;
+using Rebus.Messages;
+
+namespace Rebus.GoogleCloudPubSub.Messages;
+
+public interface IMessageConverter
+{
+    TransportMessage ToTransport(PubsubMessage message);
+    PubsubMessage ToPubsub(TransportMessage transportMessage);
+}

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/PubSubTransportMessage.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/PubSubTransportMessage.cs
@@ -1,8 +1,0 @@
-﻿namespace Rebus.GoogleCloudPubSub
-{
-    public class PubSubTransportMessage
-    {
-        public byte[] Headers { get; set; }
-        public byte[] Body { get; set; }
-    }
-}

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/TransportMessageExtensions.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/TransportMessageExtensions.cs
@@ -1,53 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using Google.Cloud.PubSub.V1;
-using Google.Protobuf;
-using Newtonsoft.Json;
-using Rebus.Extensions;
 using Rebus.Messages;
 
-namespace Rebus.GoogleCloudPubSub
+namespace Rebus.GoogleCloudPubSub;
+
+public static class TransportMessageExtensions
 {
-    public static class TransportMessageExtensions
+    public static DateTimeOffset AbsoluteExpiryTimeUtc(this TransportMessage message)
     {
-        public static DateTimeOffset AbsoluteExpiryTimeUtc(this TransportMessage message)
-        {
-            if (message == null) throw new ArgumentNullException(nameof(message));
+        if (message == null) throw new ArgumentNullException(nameof(message));
+        if (message.Headers.ContainsKey(Headers.TimeToBeReceived) && message.Headers.ContainsKey(Headers.SentTime))
+            if (TimeSpan.TryParse(message.Headers[Headers.TimeToBeReceived], out var timeToBeReceived) &&
+                DateTimeOffset.TryParse(message.Headers[Headers.SentTime], out var sentTime))
+                return sentTime.Add(timeToBeReceived).ToUniversalTime();
 
-            if (message.Headers.ContainsKey(Headers.TimeToBeReceived) && message.Headers.ContainsKey(Headers.SentTime))
-            {
-                if (TimeSpan.TryParse(message.Headers[Headers.TimeToBeReceived], out var timeToBeReceived) && DateTimeOffset.TryParse(message.Headers[Headers.SentTime], out var sentTime))
-                {
-                    return sentTime.Add(timeToBeReceived).ToUniversalTime();
-                }
-            }
-            return DateTimeOffset.MinValue;
-        }
+        return DateTimeOffset.MinValue;
+    }
 
-        public static bool IsExpired(this TransportMessage message, DateTimeOffset comparedTo)
-        {
-            if (message == null) throw new ArgumentNullException(nameof(message));
-
-            var absoluteExpiry = message.AbsoluteExpiryTimeUtc();
-            return absoluteExpiry > DateTimeOffset.MinValue && absoluteExpiry < comparedTo;
-        }
-
-        public static TransportMessage ToRebusTransportMessage(this ReceivedMessage message)
-        {
-            var msg = JsonConvert.DeserializeObject<PubSubTransportMessage>(System.Text.Encoding.UTF8.GetString(message.Message.Data.ToByteArray()));
-            var headers = JsonConvert.DeserializeObject<Dictionary<string, string>>(System.Text.Encoding.UTF8.GetString(msg.Headers));
-            return new TransportMessage(headers, msg.Body);
-        }
-
-        public static PubsubMessage ToPubSubMessage(this TransportMessage msg)
-        {
-            var rebusTransportMessage = msg;
-            var transport = new PubSubTransportMessage { Headers = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(rebusTransportMessage.Headers)), Body = rebusTransportMessage.Body };
-            return new PubsubMessage
-            {
-                MessageId = rebusTransportMessage.Headers.GetValue(Headers.MessageId),
-                Data = ByteString.CopyFrom(System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(transport)))
-            };
-        }
+    public static bool IsExpired(this TransportMessage message, DateTimeOffset comparedTo)
+    {
+        if (message == null) throw new ArgumentNullException(nameof(message));
+        var absoluteExpiry = message.AbsoluteExpiryTimeUtc();
+        return absoluteExpiry > DateTimeOffset.MinValue && absoluteExpiry < comparedTo;
     }
 }

--- a/Rebus.GoogleCloudPubSub/Rebus.GoogleCloudPubSub.csproj
+++ b/Rebus.GoogleCloudPubSub/Rebus.GoogleCloudPubSub.csproj
@@ -24,7 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Google.Cloud.PubSub.V1" Version="3.8.0" />
+		<PackageReference Include="Google.Cloud.PubSub.V1" Version="3.16.0" />
 		<PackageReference Include="rebus" Version="8.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
This change introduces support for a custom message converter to handle conversions between Rebus and Google Pub/Sub, allowing greater flexibility in serializing and deserializing messages.

BREAKING CHANGE: this improvement changes the library's default conversion.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
