### PR TITLE
feat(lease-management): add support for message lease renewal

### DIFF
--- a/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
@@ -2,44 +2,49 @@
 using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Tests.Contracts.Transports;
+using Rebus.Threading.TaskParallelLibrary;
 using Rebus.Transport;
 
-namespace Rebus.GoogleCloudPubSub.Tests.Factory
+namespace Rebus.GoogleCloudPubSub.Tests.Factory;
+
+public class GoogleCloudPubSubTransportFactory : ITransportFactory
 {
-    public class GoogleCloudPubSubTransportFactory : ITransportFactory
+    private readonly ConcurrentStack<GoogleCloudPubSubTransport> _disposables = new();
+    private static string ProjectId => GoogleCredentials.GetProjectIdFromGoogleCredentials();
+    
+    
+    
+
+    public ITransport CreateOneWayClient()
     {
-        readonly ConcurrentStack<GoogleCloudPubSubTransport> _disposables = new();
+        var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+        var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver, consoleLoggerFactory,
+            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter());
 
-        public ITransport CreateOneWayClient()
+        _disposables.Push(transport);
+
+        return transport;
+    }
+
+    public ITransport Create(string inputQueueAddress)
+    {
+        var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+        var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueueAddress, consoleLoggerFactory,
+            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter());
+        transport.PurgeQueueAsync().ConfigureAwait(false);
+        transport.Initialize();
+
+        _disposables.Push(transport);
+
+        return transport;
+    }
+
+    public void CleanUp()
+    {
+        while (_disposables.TryPop(out var disposable))
         {
-            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver, consoleLoggerFactory, new DefaultMessageConverter());
-
-            _disposables.Push(transport);
-
-            return transport;
+            disposable.PurgeQueueAsync().ConfigureAwait(false);
+            disposable.Dispose();
         }
-
-        public ITransport Create(string inputQueueAddress)
-        {
-            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueueAddress, consoleLoggerFactory, new DefaultMessageConverter());
-            transport.PurgeQueueAsync().ConfigureAwait(false);
-            transport.Initialize();
-
-            _disposables.Push(transport);
-
-            return transport;
-        }
-
-        public void CleanUp()
-        {
-            while (_disposables.TryPop(out var disposable))
-            {
-                disposable.PurgeQueueAsync().ConfigureAwait(false);
-                disposable.Dispose();
-            }
-        }
-        private static string ProjectId => GoogleCredentials.GetProjectIdFromGoogleCredentials();
     }
 }

--- a/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSubLeaseRenewalTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSubLeaseRenewalTest.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Extensions;
+using Rebus.GoogleCloudPubSub.Messages;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Tests.Contracts.Utilities;
+using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Transport;
+using Rebus.Workers.TplBased;
+
+namespace Rebus.GoogleCloudPubSub.Tests;
+
+[TestFixture]
+public class GoogleCloudPubSubLeaseRenewalTest : GoogleCloudFixtureBase
+{
+    private const string QueueName = "your-subscription-name";
+
+    readonly ConsoleLoggerFactory _consoleLoggerFactory = new(false);
+    BuiltinHandlerActivator _activator;
+    GoogleCloudPubSubTransport _transport;
+    IBus _bus;
+    IBusStarter _busStarter;
+
+    protected override void SetUp()
+    {
+        _transport = new GoogleCloudPubSubTransport(
+            ProjectId,
+            QueueName,
+            _consoleLoggerFactory,
+            new TplAsyncTaskFactory(_consoleLoggerFactory),
+            new DefaultMessageConverter()
+        );
+
+        Using(_transport);
+        _transport.Initialize();
+        AsyncHelpers.RunSync(() => _transport.PurgeQueueAsync());
+        
+        _activator = new BuiltinHandlerActivator();
+        _busStarter = Configure.With(_activator)
+            .Logging(l => l.Use(new ListLoggerFactory(outputToConsole: true, detailed: true)))
+            .Transport(t => t.UsePubSub(ProjectId, QueueName))
+            .Options(o =>
+            {
+                o.UseTplToReceiveMessages();
+            })
+            .Create();
+
+        _bus = _busStarter.Bus;
+        Using(_bus);
+    }
+
+    [Test]
+    public async Task LeaseRenewalWorks()
+    {
+        var gotMessage = new ManualResetEvent(false);
+
+        _activator.Handle<string>(async (bus, context, message) =>
+        {
+            Console.WriteLine($"Received message with ID {context.Headers.GetValue(Headers.MessageId)} - processing...");
+            
+            await Task.Delay(TimeSpan.FromMinutes(3));
+
+            Console.WriteLine("Finished processing message.");
+            gotMessage.Set();
+        });
+
+        _busStarter.Start();
+        
+        await _bus.SendLocal("Test message for lease renewal");
+        
+        Assert.IsTrue(gotMessage.WaitOne(TimeSpan.FromMinutes(3.5)), "Message was not processed in time.");
+        
+        _bus.Dispose();
+        
+        using var scope = new RebusTransactionScope();
+        var message = await _transport.Receive(scope.TransactionContext, CancellationToken.None);
+        await scope.CompleteAsync();
+
+        Assert.IsNull(message, "Expected no message, but found one.");
+    }
+}

--- a/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
+++ b/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+    </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.16.0" />
@@ -13,14 +13,14 @@
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Rebus.GoogleCloudPubSub\Rebus.GoogleCloudPubSub.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Rebus.GoogleCloudPubSub\Rebus.GoogleCloudPubSub.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="google-cloud-credentials.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="google-cloud-credentials.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/Rebus.GoogleCloudPubSub.Tests/WithSomeLuck.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/WithSomeLuck.cs
@@ -11,206 +11,201 @@ using Rebus.Logging;
 using Rebus.Persistence.InMem;
 using Rebus.Routing.TypeBased;
 using Rebus.Tests.Contracts.Extensions;
+using Rebus.Threading;
 using Rebus.Transport;
 
-namespace Rebus.GoogleCloudPubSub.Tests
+namespace Rebus.GoogleCloudPubSub.Tests;
+
+public static class TestTransportConfigurer
 {
+    private static string ProjectId => GoogleCredentials.GetProjectIdFromGoogleCredentials();
 
-    public static class TestTransportConfigurer
+    public static void UsePubSubAndPurgeQueueAtStartup(this StandardConfigurer<ITransport> configurer,
+        string inputQueueName)
     {
-        public static void UsePubSubAndPurgeQueueAtStartup(this StandardConfigurer<ITransport> configurer, string inputQueueName)
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
+        configurer.Register(c =>
         {
-            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-            if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
-            configurer.Register(c =>
-            {
-                var googleCloudPubSubTransport = new GoogleCloudPubSubTransport(ProjectId, inputQueueName, c.Get<IRebusLoggerFactory>(), new DefaultMessageConverter());
-                AsyncHelpers.RunSync(googleCloudPubSubTransport.PurgeQueueAsync);
-                return googleCloudPubSubTransport;
-            });
-        }
-        private static string ProjectId => GoogleCredentials.GetProjectIdFromGoogleCredentials();
+            var googleCloudPubSubTransport = new GoogleCloudPubSubTransport(ProjectId, inputQueueName,
+                c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), new DefaultMessageConverter());
+            AsyncHelpers.RunSync(googleCloudPubSubTransport.PurgeQueueAsync);
+            return googleCloudPubSubTransport;
+        });
     }
-    [TestFixture]
-    public class WithSomeLuck : GoogleCloudFixtureBase
-    {
-        [Test]
-        public async Task BasicSendReceiveTestWillSucceed()
-        {
-            var gotTheString = Using(new ManualResetEvent(initialState: false));
-            var receiver = Using(new BuiltinHandlerActivator());
+}
 
-            receiver.Handle<string>(async msg =>
+[TestFixture]
+public class WithSomeLuck : GoogleCloudFixtureBase
+{
+    [Test]
+    public async Task BasicSendReceiveTestWillSucceed()
+    {
+        var gotTheString = Using(new ManualResetEvent(false));
+        var receiver = Using(new BuiltinHandlerActivator());
+
+        receiver.Handle<string>(async msg =>
+        {
+            Console.WriteLine($"Got message from queue: {msg}");
+            gotTheString.Set();
+        });
+
+        Configure.With(receiver)
+            .Transport(t => t.UsePubSub(ProjectId, Constants.Receiver))
+            .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
+            .Start();
+
+        var sender = Configure.With(Using(new BuiltinHandlerActivator()))
+            .Transport(t => t.UsePubSub(ProjectId, Constants.Sender))
+            .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
+            .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
+            .Start();
+
+        await sender.Send($"Some fancy message {Guid.NewGuid():N} 😎");
+
+        gotTheString.WaitOrDie(
+            TimeSpan.FromSeconds(10),
+            "Did not receive any string within 5 s timeout"
+        );
+        await Task.Delay(5000);
+    }
+
+    private static int _msgCounter;
+
+    [Test]
+    public async Task ItWillSendAndReceive100MessagesWithoutTooMuchDelay()
+    {
+        Stopwatch w = null;
+
+        var expectedCount = 50;
+        var gotTheString = Using(new ManualResetEvent(false));
+        var receiver = Using(new BuiltinHandlerActivator());
+
+
+        receiver.Handle<string>(async msg =>
+        {
+            Interlocked.Increment(ref _msgCounter);
+            Console.WriteLine($"Got message {_msgCounter} from queue: {msg}");
+            if (_msgCounter == expectedCount)
             {
-                Console.WriteLine($"Got message from queue: {msg}");
+                Console.WriteLine(
+                    $"Time spent sending and receiving {_msgCounter} messages was {w.ElapsedMilliseconds} ms");
                 gotTheString.Set();
-            });
-
-            Configure.With(receiver)
-                .Transport(t => t.UsePubSub(ProjectId,Constants.Receiver))
-                .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
-                .Start();
-
-            var sender = Configure.With(Using(new BuiltinHandlerActivator()))
-                .Transport(t => t.UsePubSub(ProjectId,Constants.Sender))
-                .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
-
-                .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
-                .Start();
-
-            await sender.Send($"Some fancy message {Guid.NewGuid():N} 😎");
-
-            gotTheString.WaitOrDie(
-                timeout: TimeSpan.FromSeconds(10),
-                errorMessage: "Did not receive any string within 5 s timeout"
-            );
-            await Task.Delay(5000);
-        }
-
-        static int _msgCounter;
-        [Test]
-        public async Task ItWillSendAndReceive100MessagesWithoutTooMuchDelay()
-        {
-            Stopwatch w = null;
-
-            int expectedCount = 50;
-            var gotTheString = Using(new ManualResetEvent(initialState: false));
-            var receiver = Using(new BuiltinHandlerActivator());
-
-
-            receiver.Handle<string>(async msg =>
-            {
-                Interlocked.Increment(ref _msgCounter);
-                Console.WriteLine($"Got message {_msgCounter} from queue: {msg}");
-                if (_msgCounter == expectedCount)
-                {
-                    Console.WriteLine($"Time spent sending and receiving {_msgCounter} messages was {w.ElapsedMilliseconds} ms");
-                    gotTheString.Set();
-                }
-            });
-
-            Configure.With(receiver)
-                .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Receiver))
-                    .Start();
-
-            var sender = Configure.With(Using(new BuiltinHandlerActivator()))
-                .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Sender))
-                .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
-                .Start();
-
-            w = Stopwatch.StartNew();
-            for (int i = 0; i < expectedCount; i++)
-            {
-                await sender.Send($"Some fancy message {i} 😎");
             }
+        });
 
-            var wait = TimeSpan.FromMinutes(1);
-            gotTheString.WaitOrDie(
-                timeout: wait,
-                errorMessage: $"Did not receive {expectedCount} within {wait} time"
-            );
-        }
+        Configure.With(receiver)
+            .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Receiver))
+            .Start();
 
+        var sender = Configure.With(Using(new BuiltinHandlerActivator()))
+            .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Sender))
+            .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
+            .Start();
 
-        [Test]
-        public async Task ItWillWorkWihoutNativeSubscriptionStorage()
-        {
+        w = Stopwatch.StartNew();
+        for (var i = 0; i < expectedCount; i++) await sender.Send($"Some fancy message {i} 😎");
 
-            var store = new InMemorySubscriberStore();
-
-            var gotExpectedMessages = Using(new ManualResetEvent(initialState: false));
-            var receiver = Using(new BuiltinHandlerActivator());
-
-            receiver.Register(() => new SomeSimpleHandler(gotExpectedMessages));
-
-
-            var receiverBus = Configure.With(receiver)
-                .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Receiver))
-                .Subscriptions(s => s.StoreInMemory(store))
-                .Start();
-
-
-            await receiverBus.Subscribe<MessageToSubscribeA>();
-            await receiverBus.Subscribe<MessageToSubscribeB>();
-
-            var sender = Configure.With(Using(new BuiltinHandlerActivator()))
-                .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Sender))
-                .Subscriptions(s => s.StoreInMemory(store))
-                .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
-                .Start();
-
-            await sender.Send("Some fancy message");
-            await sender.Publish(new MessageToSubscribeA() { Data = "MessageToSubscribeA" });
-            await sender.Publish(new MessageToSubscribeB() { Data = "MessageToSubscribeB" });
-            await sender.Publish(new MessageToSubscribeC() { Data = "MessageToSubscribeC" });
-
-
-
-            var wait = TimeSpan.FromSeconds(20);
-            gotExpectedMessages.WaitOrDie(
-                timeout: wait,
-                errorMessage: $"Did not receive expected messages"
-            );
-        }
-
+        var wait = TimeSpan.FromMinutes(1);
+        gotTheString.WaitOrDie(
+            wait,
+            $"Did not receive {expectedCount} within {wait} time"
+        );
     }
 
-    public class MessageToSubscribeA
+
+    [Test]
+    public async Task ItWillWorkWihoutNativeSubscriptionStorage()
     {
-        public string Data { get; set; }
+        var store = new InMemorySubscriberStore();
+
+        var gotExpectedMessages = Using(new ManualResetEvent(false));
+        var receiver = Using(new BuiltinHandlerActivator());
+
+        receiver.Register(() => new SomeSimpleHandler(gotExpectedMessages));
+
+
+        var receiverBus = Configure.With(receiver)
+            .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Receiver))
+            .Subscriptions(s => s.StoreInMemory(store))
+            .Start();
+
+
+        await receiverBus.Subscribe<MessageToSubscribeA>();
+        await receiverBus.Subscribe<MessageToSubscribeB>();
+
+        var sender = Configure.With(Using(new BuiltinHandlerActivator()))
+            .Transport(t => t.UsePubSubAndPurgeQueueAtStartup(Constants.Sender))
+            .Subscriptions(s => s.StoreInMemory(store))
+            .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
+            .Start();
+
+        await sender.Send("Some fancy message");
+        await sender.Publish(new MessageToSubscribeA { Data = "MessageToSubscribeA" });
+        await sender.Publish(new MessageToSubscribeB { Data = "MessageToSubscribeB" });
+        await sender.Publish(new MessageToSubscribeC { Data = "MessageToSubscribeC" });
+
+
+        var wait = TimeSpan.FromSeconds(20);
+        gotExpectedMessages.WaitOrDie(
+            wait,
+            "Did not receive expected messages"
+        );
+    }
+}
+
+public class MessageToSubscribeA
+{
+    public string Data { get; set; }
+}
+
+public class MessageToSubscribeB
+{
+    public string Data { get; set; }
+}
+
+public class MessageToSubscribeC
+{
+    public string Data { get; set; }
+}
+
+public class SomeSimpleHandler :
+    IHandleMessages<string>,
+    IHandleMessages<MessageToSubscribeA>,
+    IHandleMessages<MessageToSubscribeB>
+{
+    private static bool gotMessageA;
+    private static bool gotMessageB;
+    private static bool gotSomeStringSentDirectly;
+    private readonly ManualResetEvent _evnt;
+
+    public SomeSimpleHandler(ManualResetEvent evnt)
+    {
+        _evnt = evnt;
     }
 
-    public class MessageToSubscribeB
+    public async Task Handle(MessageToSubscribeA message)
     {
-        public string Data { get; set; }
+        gotMessageA = true;
+        ShouldReset();
     }
 
-    public class MessageToSubscribeC
+    public async Task Handle(MessageToSubscribeB message)
     {
-        public string Data { get; set; }
+        gotMessageB = true;
+        ShouldReset();
     }
 
-    public class SomeSimpleHandler :
-        IHandleMessages<string>,
-        IHandleMessages<MessageToSubscribeA>,
-        IHandleMessages<MessageToSubscribeB>
+    public async Task Handle(string message)
     {
-        private readonly ManualResetEvent _evnt;
-        static bool gotMessageA = false;
-        static bool gotMessageB = false;
-        static bool gotSomeStringSentDirectly = false;
+        if (message.Contains("Some fancy message"))
+            gotSomeStringSentDirectly = true;
 
-        public SomeSimpleHandler(ManualResetEvent evnt)
-        {
-            _evnt = evnt;
-        }
-        public async Task Handle(string message)
-        {
-            if (message.Contains("Some fancy message"))
-                gotSomeStringSentDirectly = true;
+        ShouldReset();
+    }
 
-            ShouldReset();
-        }
-
-        public async Task Handle(MessageToSubscribeA message)
-        {
-            gotMessageA = true;
-            ShouldReset();
-        }
-
-        public async Task Handle(MessageToSubscribeB message)
-        {
-            gotMessageB = true;
-            ShouldReset();
-        }
-
-        private void ShouldReset()
-        {
-            if (gotMessageA && gotMessageB && gotSomeStringSentDirectly)
-            {
-                _evnt.Set();
-            }
-
-        }
+    private void ShouldReset()
+    {
+        if (gotMessageA && gotMessageB && gotSomeStringSentDirectly) _evnt.Set();
     }
 }

--- a/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
+++ b/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 using Rebus.GoogleCloudPubSub;
 using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
+using Rebus.Threading;
 using Rebus.Transport;
 
 namespace Rebus.Config;
@@ -14,8 +15,8 @@ public static class GoogleCloudPubSubTransportConfigurationExtensions
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
         if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
         configurer.Register(c => new GoogleCloudPubSubTransport(projectId, inputQueueName,
-            c.Get<IRebusLoggerFactory>(), c.Get<IMessageConverter>()));
-        
+            c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), c.Get<IMessageConverter>()));
+
         configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
     }
 
@@ -23,9 +24,9 @@ public static class GoogleCloudPubSubTransportConfigurationExtensions
     {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
         configurer.Register(c =>
-            new GoogleCloudPubSubTransport(projectId, null, c.Get<IRebusLoggerFactory>(),
+            new GoogleCloudPubSubTransport(projectId, null, c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(),
                 c.Get<IMessageConverter>()));
-        
+
         configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
     }
 }

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/GoogleCloudPubSubTransport.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/GoogleCloudPubSubTransport.cs
@@ -13,6 +13,7 @@ using Rebus.Exceptions;
 using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Messages;
+using Rebus.Threading;
 using Rebus.Transport;
 
 namespace Rebus.GoogleCloudPubSub;
@@ -21,16 +22,20 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
 {
     private readonly ConcurrentDictionary<string, Lazy<Task<PublisherClient>>> _clients = new();
     private readonly string _inputQueueName;
+    private IAsyncTask _leaseRenewalTimer;
+    private readonly ConcurrentDictionary<string, MessageLeaseRenewer> _leaseRenewers = new();
     private readonly IMessageConverter _messageConverter;
+    private readonly IAsyncTaskFactory _asyncTaskFactory;
     private readonly string _projectId;
     protected readonly ILog Log;
 
     private TopicName _inputTopic;
     private SubscriberServiceApiClient _subscriberClient;
     private SubscriptionName _subscriptionName;
-
+    private Subscription _subscription;
 
     public GoogleCloudPubSubTransport(string projectId, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory,
+        IAsyncTaskFactory asyncTaskFactory,
         IMessageConverter messageConverter) : base(inputQueueName)
     {
         _projectId = projectId ?? throw new ArgumentNullException(nameof(projectId));
@@ -38,10 +43,12 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
         if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
         Log = rebusLoggerFactory.GetLogger<GoogleCloudPubSubTransport>();
         _messageConverter = messageConverter ?? throw new ArgumentNullException(nameof(messageConverter));
+        _asyncTaskFactory = asyncTaskFactory ?? throw new ArgumentNullException(nameof(asyncTaskFactory));
     }
 
     public void Dispose()
     {
+        _leaseRenewalTimer?.Dispose();
     }
 
     public void Initialize()
@@ -51,7 +58,46 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
             _inputTopic = new TopicName(_projectId, _inputQueueName);
             CreateQueue(_inputQueueName);
             AsyncHelpers.RunSync(CreateSubscriptionAsync);
+            SetupLeaseRenewalTimer(_subscription.AckDeadlineSeconds);
         }
+        
+    }
+
+    private void SetupLeaseRenewalTimer(int ackDeadlineSeconds)
+    {
+        var renewIntervalSeconds = ackDeadlineSeconds / 2;
+        _leaseRenewalTimer = _asyncTaskFactory.Create("Lease Renewal", RenewLeases, true, renewIntervalSeconds);
+        _leaseRenewalTimer.Start();
+    }
+
+    private async Task RenewLeases()
+    {
+        var leaseRenewer = _leaseRenewers
+            .Where(r => r.Value.IsDue)
+            .Select(kvp => kvp.Value)
+            .ToList();
+
+        if (!leaseRenewer.Any()) return;
+
+        Log.Debug("Identified {count} message leases that are due for renewal to prevent expiration",
+            leaseRenewer.Count);
+
+        await Task.WhenAll(leaseRenewer.Select(async messageLeaseRenewer =>
+        {
+            try
+            {
+                await messageLeaseRenewer.RenewAsync().ConfigureAwait(false);
+
+                Log.Debug("Successfully renewed lease for message with ID {messageId}", messageLeaseRenewer.MessageId);
+            }
+            catch (Exception ex)
+            {
+                if (!_leaseRenewers.ContainsKey(messageLeaseRenewer.ReceivedMessage.Message.MessageId)) return;
+
+                Log.Warn(ex, "Error when renewing lease for message with ID {messageId}",
+                    messageLeaseRenewer.MessageId);
+            }
+        }));
     }
 
     private async Task<PublisherServiceApiClient> GetPublisherServiceApiClientAsync()
@@ -121,19 +167,20 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
 
         try
         {
-            await _subscriberClient.GetSubscriptionAsync(_subscriptionName);
+            _subscription = await _subscriberClient.GetSubscriptionAsync(_subscriptionName);
         }
         catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
         {
             var retries = 0;
-            var maxRetries = 10;
+            var maxRetries = 100;
             while (retries < maxRetries)
                 try
                 {
                     await _subscriberClient.CreateSubscriptionAsync(_subscriptionName.ToString(),
                         _inputTopic.ToString(), null, 30);
+                    _subscription = await _subscriberClient.GetSubscriptionAsync(_subscriptionName);
                     //wait after subscription is created - because some delay on google's side
-                    await Task.Delay(5000);
+                    await Task.Delay(2500);
                     Log.Info("Created subscription {sub} for topic {topic}", _subscriptionName.ToString(),
                         _inputTopic.ToString());
                     break;
@@ -145,7 +192,6 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
                     retries++;
                     if (retries == maxRetries)
                         throw new RebusApplicationException($"Could not create subscription topic {_inputTopic}");
-                    await Task.Delay(1000 * retries);
                 }
         }
     }
@@ -193,15 +239,19 @@ public class GoogleCloudPubSubTransport : AbstractRebusTransport, IInitializable
             return null;
         }
 
+        var leaseRenewer = new MessageLeaseRenewer(receivedMessage, _subscriberClient, _subscriptionName, _subscription.AckDeadlineSeconds);
+        _leaseRenewers.TryAdd(receivedMessage.Message.MessageId, leaseRenewer);
 
         context.OnAck(async ctx =>
         {
             await _subscriberClient.AcknowledgeAsync(_subscriptionName, new[] { receivedMessage.AckId });
+            _leaseRenewers.TryRemove(receivedMessage.Message.MessageId, out _);
         });
 
         context.OnNack(async ctx =>
         {
             await _subscriberClient.ModifyAckDeadlineAsync(_subscriptionName, new[] { receivedMessage.AckId }, 0);
+            _leaseRenewers.TryRemove(receivedMessage.Message.MessageId, out _);
         });
 
         return receivedTransportMessage;

--- a/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/MessageLeaseRenewer.cs
+++ b/Rebus.GoogleCloudPubSub/GoogleCloudPubSub/MessageLeaseRenewer.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Google.Cloud.PubSub.V1;
+
+namespace Rebus.GoogleCloudPubSub;
+
+internal class MessageLeaseRenewer
+{
+    private readonly int _ackDeadlineSeconds;
+    private readonly SubscriberServiceApiClient _subscriberClient;
+    private readonly SubscriptionName _subscriptionName;
+    public readonly ReceivedMessage ReceivedMessage;
+    private DateTimeOffset _nextRenewal;
+
+
+    public MessageLeaseRenewer(ReceivedMessage receivedMessage, SubscriberServiceApiClient subscriberClient,
+        SubscriptionName subscriptionName, int ackDeadlineSeconds)
+    {
+        ReceivedMessage = receivedMessage;
+        _subscriberClient = subscriberClient;
+        _subscriptionName = subscriptionName;
+        _ackDeadlineSeconds = ackDeadlineSeconds;
+        _nextRenewal = CalculateNextRenewalTime();
+    }
+
+    public string MessageId => ReceivedMessage.Message.MessageId;
+
+    /// <summary>
+    ///     Checks if the lease renewal is due based on the current time.
+    /// </summary>
+    public bool IsDue => DateTimeOffset.Now >= _nextRenewal;
+
+    /// <summary>
+    ///     Renews the lease for the message by extending the acknowledgement deadline.
+    /// </summary>
+    public async Task RenewAsync()
+    {
+        await _subscriberClient.ModifyAckDeadlineAsync(_subscriptionName, new[] { ReceivedMessage.AckId }, _ackDeadlineSeconds);
+        _nextRenewal = CalculateNextRenewalTime();
+    }
+
+    /// <summary>
+    ///     Calculates the next time at which the lease should be renewed.
+    /// </summary>
+    /// <returns>The time of the next renewal.</returns>
+    private DateTimeOffset CalculateNextRenewalTime()
+    {
+        var now = DateTimeOffset.Now;
+        var renewInterval = TimeSpan.FromSeconds(_ackDeadlineSeconds * 0.5);
+        return now + renewInterval;
+    }
+}


### PR DESCRIPTION
Introduced a new lease management feature that automatically extends the acknowledgment deadline for messages that have not yet been acknowledged. This implementation allows for more granular control over message processing times, preventing premature message expiration and redelivery.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
