### PR TITLE
feat(pubsub): add support for manual resource configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
 WORKDIR /app
 
 COPY Rebus.GoogleCloudPubSub/*.csproj ./Rebus.GoogleCloudPubSub/
@@ -8,5 +8,9 @@ COPY Rebus.GoogleCloudPubSub.sln .
 RUN dotnet restore
 
 COPY . ./
+
+RUN apt-get update && apt-get install -y curl && \
+    curl -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh 
+
 FROM build-env AS test
-CMD dotnet test --collect:"XPlat Code Coverage" --test-adapter-path:. --logger:"junit;LogFilePath=/tmp/testresults.run/{assembly}-test-result.xml;MethodFormat==Class;FailureBodyFormat=Verbose" --results-directory /tmp/testresults.run ; mkdir -p /tmp/testresults.host/testreports && cp -r /tmp/testresults.run/* /tmp/testresults.host/testreports/

--- a/Rebus.GoogleCloudPubSub.Tests/AckDeadlineSecondsTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/AckDeadlineSecondsTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Extensions;
+using Rebus.GoogleCloudPubSub.Messages;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Transport;
+
+namespace Rebus.GoogleCloudPubSub.Tests;
+
+[TestFixture]
+public class AckDeadlineSecondsTest : GoogleCloudFixtureBase
+{
+    private const string QueueName = "test-topic:test-subscription";
+    private const int MaxAckDeadlineSeconds = 3;
+    private readonly ConsoleLoggerFactory _consoleLoggerFactory = new(false);
+    private BuiltinHandlerActivator _activator;
+    private GoogleCloudPubSubTransport _transport;
+    private IBus _bus;
+    private IBusStarter _busStarter;
+
+    private void SetUp(int maxParallelism)
+    {
+        _transport = new GoogleCloudPubSubTransport(ProjectId, QueueName, _consoleLoggerFactory,
+            new TplAsyncTaskFactory(_consoleLoggerFactory), new DefaultMessageConverter(),
+            new GoogleCloudPubSubTransportSettings());
+        Using(_transport);
+        _transport.Initialize();
+        AsyncHelpers.RunSync(() => _transport.PurgeQueueAsync());
+        _activator = new BuiltinHandlerActivator();
+        _busStarter = Configure.With(_activator).Logging(l => l.Use(_consoleLoggerFactory)).Transport(t =>
+            t.UsePubSub(ProjectId, QueueName).SetAckDeadlineSeconds(MaxAckDeadlineSeconds)).Options(o =>
+        {
+            o.SetNumberOfWorkers(1);
+            o.SetMaxParallelism(2);
+        }).Create();
+        _bus = _busStarter.Bus;
+        Using(_bus);
+    }
+
+    [Test]
+    public async Task ProcessMessageWithinAckDeadline()
+    {
+        SetUp(1);
+        var gotMessage = new ManualResetEvent(false);
+        
+        _activator.Handle<string>(async (bus, context, message) =>
+        {
+            Console.WriteLine(
+                $"Received message with ID {context.Headers.GetValue(Headers.MessageId)} - processing...");
+            await Task.Delay(TimeSpan.FromSeconds(MaxAckDeadlineSeconds * 0.1));
+            Console.WriteLine("Finished processing message.");
+            gotMessage.Set();
+        });
+        
+        _busStarter.Start();
+        
+        await _bus.SendLocal("Test message for AckDeadline");
+        
+        Assert.IsTrue(gotMessage.WaitOne(TimeSpan.FromSeconds(MaxAckDeadlineSeconds)),
+            "Message was processed in time.");
+        
+        _bus.Dispose();
+        
+        using var scope = new RebusTransactionScope();
+        var message = await _transport.Receive(scope.TransactionContext, CancellationToken.None);
+        await scope.CompleteAsync();
+        
+        Assert.IsNull(message, "Expected no message, but found one.");
+    }
+
+    [Test]
+    public async Task AckDeadlineExpiresRedeliverMessage()
+    {
+        SetUp(2);
+        var firstAttemptProcessed = new ManualResetEvent(false);
+        var secondAttemptProcessed = new ManualResetEvent(false);
+        var attemptCount = 0;
+        const int totalAttempts = 2;
+        _activator.Handle<string>(async (bus, context, message) =>
+        {
+            attemptCount++;
+            Console.WriteLine(
+                $"Received message with ID {context.Headers.GetValue(Headers.MessageId)} - processing attempt {attemptCount}...");
+            if (attemptCount == 1)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(MaxAckDeadlineSeconds * 3));
+                Console.WriteLine("First attempt: Message Processing took too long, ack deadline expired.");
+                firstAttemptProcessed.Set();
+            }
+            else
+            {
+                Console.WriteLine("Second attempt: Message redelivered and processed.");
+                secondAttemptProcessed.Set();
+            }
+        });
+        
+        _busStarter.Start();
+        
+        await _bus.SendLocal("Test message for AckDeadlineExpiration");
+        
+        Assert.IsTrue(secondAttemptProcessed.WaitOne(TimeSpan.FromSeconds(MaxAckDeadlineSeconds * totalAttempts)),
+            "Second attempt, the message was redelivered and did not process in time.");
+        
+        Assert.IsFalse(firstAttemptProcessed.WaitOne(TimeSpan.FromSeconds(MaxAckDeadlineSeconds)),
+            "First attempt did not process in time.");
+        
+        _bus.Dispose();
+    }
+}

--- a/Rebus.GoogleCloudPubSub.Tests/AckDeadlineSecondsTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/AckDeadlineSecondsTest.cs
@@ -18,7 +18,7 @@ namespace Rebus.GoogleCloudPubSub.Tests;
 public class AckDeadlineSecondsTest : GoogleCloudFixtureBase
 {
     private const string QueueName = "test-topic:test-subscription";
-    private const int MaxAckDeadlineSeconds = 3;
+    private const int MaxAckDeadlineSeconds = 10;
     private readonly ConsoleLoggerFactory _consoleLoggerFactory = new(false);
     private BuiltinHandlerActivator _activator;
     private GoogleCloudPubSubTransport _transport;

--- a/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubBusFactory.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubBusFactory.cs
@@ -49,7 +49,7 @@ public class GoogleCloudPubSubBusFactory : IBusFactory
         var consoleLoggerFactory = new ConsoleLoggerFactory(false);
 
         using var transport = new GoogleCloudPubSubTransport(_projectId, queueName, consoleLoggerFactory,
-            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter());
+            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter(), new GoogleCloudPubSubTransportSettings());
 
         transport.PurgeQueueAsync()
             .GetAwaiter()

--- a/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/Factory/GoogleCloudPubSubTransportFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Rebus.Config;
 using Rebus.GoogleCloudPubSub.Messages;
 using Rebus.Logging;
 using Rebus.Tests.Contracts.Transports;
@@ -11,27 +12,27 @@ public class GoogleCloudPubSubTransportFactory : ITransportFactory
 {
     private readonly ConcurrentStack<GoogleCloudPubSubTransport> _disposables = new();
     private static string ProjectId => GoogleCredentials.GetProjectIdFromGoogleCredentials();
-    
-    
-    
 
     public ITransport CreateOneWayClient()
     {
         var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-        var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver, consoleLoggerFactory,
-            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter());
+        var transport = new GoogleCloudPubSubTransport(ProjectId, Constants.Receiver,
+            consoleLoggerFactory,
+            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter(),
+            new GoogleCloudPubSubTransportSettings());
 
         _disposables.Push(transport);
 
         return transport;
     }
 
-    public ITransport Create(string inputQueueAddress)
+    public ITransport Create(string inputQueue)
     {
         var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-        var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueueAddress, consoleLoggerFactory,
-            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter());
-        transport.PurgeQueueAsync().ConfigureAwait(false);
+        var transport = new GoogleCloudPubSubTransport(ProjectId, inputQueue, consoleLoggerFactory,
+            new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultMessageConverter(),
+            new GoogleCloudPubSubTransportSettings());
+        transport.PurgeQueueAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         transport.Initialize();
 
         _disposables.Push(transport);

--- a/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSubLeaseRenewalTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/GoogleCloudPubSubLeaseRenewalTest.cs
@@ -19,8 +19,8 @@ namespace Rebus.GoogleCloudPubSub.Tests;
 [TestFixture]
 public class GoogleCloudPubSubLeaseRenewalTest : GoogleCloudFixtureBase
 {
-    private const string QueueName = "your-subscription-name";
-
+    private const string QueueName = "topicName:subscriptionName";
+    
     readonly ConsoleLoggerFactory _consoleLoggerFactory = new(false);
     BuiltinHandlerActivator _activator;
     GoogleCloudPubSubTransport _transport;
@@ -34,7 +34,8 @@ public class GoogleCloudPubSubLeaseRenewalTest : GoogleCloudFixtureBase
             QueueName,
             _consoleLoggerFactory,
             new TplAsyncTaskFactory(_consoleLoggerFactory),
-            new DefaultMessageConverter()
+            new DefaultMessageConverter(),
+            new GoogleCloudPubSubTransportSettings()
         );
 
         Using(_transport);

--- a/Rebus.GoogleCloudPubSub.Tests/NotCreatingResourcesTest.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/NotCreatingResourcesTest.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using Grpc.Core;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+
+namespace Rebus.GoogleCloudPubSub.Tests;
+
+[TestFixture]
+public class NotCreatingResourcesTest : GoogleCloudFixtureBase
+{
+    [Test]
+    public async Task ShouldNotCreateTopicOrSubscriptionWhenConfiguredNotTo()
+    {
+        var topicName = "any-topic-name";
+        var subscriptionName = "any-subscription-name";
+        var queueName = $"{topicName}:{subscriptionName}";
+
+        var publisherClient = await new PublisherServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+        }.BuildAsync();
+
+        var subscriberClient = await new SubscriberServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+        }.BuildAsync();
+
+
+        var activator = Using(new BuiltinHandlerActivator());
+
+        Configure.With(activator)
+            .Logging(l => l.ColoredConsole())
+            .Transport(t =>
+            {
+                t.UsePubSub(ProjectId, queueName)
+                    .SkipResourceCreation();
+            })
+            .Start();
+
+        var topicExists = await TopicExistsAsync(publisherClient, ProjectId, topicName);
+        Assert.That(topicExists, Is.False);
+
+        var subscriptionExists = await SubscriptionExistsAsync(subscriberClient, ProjectId, subscriptionName);
+        Assert.That(subscriptionExists, Is.False);
+    }
+
+    private static async Task<bool> TopicExistsAsync(PublisherServiceApiClient client, string projectId, string topicId)
+    {
+        try
+        {
+            await client.GetTopicAsync(TopicName.FromProjectTopic(projectId, topicId));
+            return true;
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> SubscriptionExistsAsync(SubscriberServiceApiClient client, string projectId,
+        string subscriptionId)
+    {
+        try
+        {
+            await client.GetSubscriptionAsync(SubscriptionName.FromProjectSubscription(projectId, subscriptionId));
+            return true;
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+}

--- a/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
+++ b/Rebus.GoogleCloudPubSub.Tests/Rebus.GoogleCloudPubSub.Tests.csproj
@@ -5,6 +5,10 @@
     </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.16.0" />
     <PackageReference Include="microsoft.net.test.sdk" Version="17.8.0" />
     <PackageReference Include="nunit" Version="3.14.0" />

--- a/Rebus.GoogleCloudPubSub.Tests/WithSomeLuck.cs
+++ b/Rebus.GoogleCloudPubSub.Tests/WithSomeLuck.cs
@@ -28,7 +28,7 @@ public static class TestTransportConfigurer
         configurer.Register(c =>
         {
             var googleCloudPubSubTransport = new GoogleCloudPubSubTransport(ProjectId, inputQueueName,
-                c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), new DefaultMessageConverter());
+                c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), new DefaultMessageConverter(), new GoogleCloudPubSubTransportSettings());
             AsyncHelpers.RunSync(googleCloudPubSubTransport.PurgeQueueAsync);
             return googleCloudPubSubTransport;
         });
@@ -52,12 +52,10 @@ public class WithSomeLuck : GoogleCloudFixtureBase
 
         Configure.With(receiver)
             .Transport(t => t.UsePubSub(ProjectId, Constants.Receiver))
-            .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
             .Start();
 
         var sender = Configure.With(Using(new BuiltinHandlerActivator()))
             .Transport(t => t.UsePubSub(ProjectId, Constants.Sender))
-            .Options(o => o.Decorate<IMessageConverter>(c => new DefaultMessageConverter()))
             .Routing(t => t.TypeBased().Map<string>(Constants.Receiver))
             .Start();
 

--- a/Rebus.GoogleCloudPubSub.sln
+++ b/Rebus.GoogleCloudPubSub.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 		docker-compose.yaml = docker-compose.yaml
+		Dockerfile = Dockerfile
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.GoogleCloudPubSub", "Rebus.GoogleCloudPubSub\Rebus.GoogleCloudPubSub.csproj", "{1DDC598A-1C02-4719-ADC9-25EDEC42B667}"

--- a/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
+++ b/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportConfigurationExtensions.cs
@@ -9,24 +9,43 @@ namespace Rebus.Config;
 
 public static class GoogleCloudPubSubTransportConfigurationExtensions
 {
-    public static void UsePubSub(this StandardConfigurer<ITransport> configurer, string projectId,
+    public static GoogleCloudPubSubTransportSettings UsePubSub(this StandardConfigurer<ITransport> configurer, string projectId,
         string inputQueueName)
     {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
         if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
-        configurer.Register(c => new GoogleCloudPubSubTransport(projectId, inputQueueName,
-            c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), c.Get<IMessageConverter>()));
+        
+        var settings = new GoogleCloudPubSubTransportSettings();
+        
+        configurer.Register(c => new GoogleCloudPubSubTransport(
+            projectId,
+            inputQueueName,
+            c.Get<IRebusLoggerFactory>(),
+            c.Get<IAsyncTaskFactory>(),
+            c.Get<IMessageConverter>(),
+            settings));
 
         configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
+        
+        return settings;
     }
 
-    public static void UsePubSubAsOneWayClient(this StandardConfigurer<ITransport> configurer, string projectId)
+    public static GoogleCloudPubSubTransportSettings UsePubSubAsOneWayClient(this StandardConfigurer<ITransport> configurer, string projectId)
     {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
-        configurer.Register(c =>
-            new GoogleCloudPubSubTransport(projectId, null, c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(),
-                c.Get<IMessageConverter>()));
+        
+        var settings = new GoogleCloudPubSubTransportSettings();
+        
+        configurer.Register(c => new GoogleCloudPubSubTransport(
+            projectId,
+            null,
+            c.Get<IRebusLoggerFactory>(),
+            c.Get<IAsyncTaskFactory>(),
+            c.Get<IMessageConverter>(),
+            settings));
 
         configurer.OtherService<IMessageConverter>().Register(c => new DefaultMessageConverter());
+        
+        return settings;
     }
 }

--- a/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportSettings.cs
+++ b/Rebus.GoogleCloudPubSub/Config/GoogleCloudPubSubTransportSettings.cs
@@ -1,0 +1,45 @@
+namespace Rebus.Config;
+
+public class GoogleCloudPubSubTransportSettings
+{
+    internal bool AutomaticLeaseRenewalEnabled { get; private set; }
+    internal bool SkipResourceCreationEnabled { get; private set; }
+    internal int AckDeadlineSeconds { get; private set; } = 30;
+
+
+    /// <summary>
+    /// Skips resource creation (topics and subscriptions). Can be used when the service does not have rights 
+    /// to create resources, or when it is expected that resources are pre-provisioned.
+    /// </summary>
+    public GoogleCloudPubSubTransportSettings SkipResourceCreation()
+    {
+        SkipResourceCreationEnabled = true;
+        return this;
+    }
+    
+    /// <summary>
+    /// Sets the acknowledgment deadline in seconds. This defines the time within which a message
+    /// must be acknowledged before it is redelivered.
+    /// </summary>
+    public GoogleCloudPubSubTransportSettings SetAckDeadlineSeconds(int seconds)
+    {
+        AckDeadlineSeconds = seconds;
+        return this;
+    }
+    
+    /// <summary>
+    /// Enables automatic lease renewal, which attempts to renew the lease on messages being processed before
+    /// they expire. This is useful for handling messages that require longer processing times.
+    /// 
+    /// Please note that lease renewal can have performance implications, so it should be used with caution. 
+    /// It is disabled by default to prioritize performance in typical scenarios where message processing 
+    /// times are expected to be short.
+    /// 
+    /// If you enable this option, ensure that you truly need it for long-running operations.
+    /// </summary>
+    public GoogleCloudPubSubTransportSettings EnableAutomaticLeaseRenewal()
+    {
+        AutomaticLeaseRenewalEnabled = true;
+        return this;
+    }
+}

--- a/Rebus.GoogleCloudPubSub/Rebus.GoogleCloudPubSub.csproj
+++ b/Rebus.GoogleCloudPubSub/Rebus.GoogleCloudPubSub.csproj
@@ -25,7 +25,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Google.Cloud.PubSub.V1" Version="3.16.0" />
-		<PackageReference Include="rebus" Version="8.0.1" />
+		<PackageReference Include="rebus" Version="8.4.0" />
 	</ItemGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,17 @@ cache:
   - packages -> **\packages.config
   - '%LocalAppData%\NuGet\Cache'
 
+environment:
+  PUBSUB_EMULATOR_HOST: localhost:8681
+  PUBSUB_PROJECT_ID: emulator
+
 before_build:
+  - docker run -d --name pubsub-emulator -p 8681:8681 messagebird/gcloud-pubsub-emulator:latest
   - appveyor-retry dotnet restore -v Minimal
 
 build_script:
   - dotnet build -c Release --no-restore
 
 test_script:
+  - Start-Sleep -Seconds 10; echo "Timer finished!"
   - dotnet test -c Release --no-restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,35 @@
 image: Visual Studio 2022
+environment:
+  PATH: $(LOCALAPPDATA)\Google\Cloud SDK\google-cloud-sdk\bin;$(APPDATA)\npm;C:\Python39;$(PATH)
+  GCLOUD_SDK_INSTALLATION_NO_PROMPT: true
+  CLOUDSDK_PYTHON: C:\Python39\python.exe
+  PUBSUB_EMULATOR_HOST: localhost:8681
+  PUBSUB_PROJECT_ID: emulator
 
 shallow_clone: true
 
 cache:
   - packages -> **\packages.config
   - '%LocalAppData%\NuGet\Cache'
+  - $(LOCALAPPDATA)\Google\Cloud SDK
+  - $(USERPROFILE)\Documents\WindowsPowerShell\Modules
 
-environment:
-  PUBSUB_EMULATOR_HOST: localhost:8681
-  PUBSUB_PROJECT_ID: emulator
+install:
+  - ps: Install-Module "GoogleCloud"
+  - ps: Import-Module "GoogleCloud"
+  - gcloud components install beta --quiet
+  - gcloud components install pubsub-emulator --quiet
 
 before_build:
-  - docker run -d --name pubsub-emulator -p 8681:8681 messagebird/gcloud-pubsub-emulator:latest
   - appveyor-retry dotnet restore -v Minimal
 
 build_script:
   - dotnet build -c Release --no-restore
 
 test_script:
-  - Start-Sleep -Seconds 10; echo "Timer finished!"
+  - ps: |
+      Start-Job -ScriptBlock {
+        gcloud beta emulators pubsub start --host-port=localhost:8681 --project=emulator
+      }
+  - sleep 10 && echo "Timer finished!"
   - dotnet test -c Release --no-restore

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,17 +2,30 @@ version: "3"
 
 services:
   pubsub:
-    image: fardog/gcloud-pubsub-emulator
-    entrypoint: ["/google-cloud-sdk/platform/pubsub-emulator/bin/cloud-pubsub-emulator", "--host=0.0.0.0", "--port=8085", "--project=dummypubsubproject"]
+    image: messagebird/gcloud-pubsub-emulator:latest
+    platform: linux/amd64
     ports:
-      - '8085:8085'
+      - "8111:8681"
+    volumes:
+      - /data
 
   tests:
     build: .
     environment:
-      - PUBSUB_EMULATOR_HOST=pubsub:8085
+      - PUBSUB_EMULATOR_HOST=pubsub:8681
       - PUBSUB_PROJECT_ID=emulator
     volumes:
       - ./:/tmp/testresults.host
+    command:
+      - /bin/sh
+      - -c
+      - |
+        wait-for-it.sh pubsub:8682 -- echo "PubSub and topics are up!" && \
+        dotnet test --collect:"XPlat Code Coverage" --test-adapter-path:. \
+        --logger:"junit;LogFilePath=/tmp/testresults.run/{assembly}-test-result.xml;MethodFormat==Class;FailureBodyFormat=Verbose" \
+        --results-directory /tmp/testresults.run && \
+        mkdir -p /tmp/testresults.host/testreports && \
+        cp -r /tmp/testresults.run/* /tmp/testresults.host/testreports/
+    
     depends_on:
       - pubsub


### PR DESCRIPTION
- Added option to skip resource creation when resources are pre-provisioned.
- Introduced an option to enable or disable automatic lease renewal for long-running message processing.
- Added configuration for setting the acknowledgment deadline (`AckDeadlineSeconds`) to control message redelivery timing.
- Fixed AppVeyor configuration to properly run the Pub/Sub emulator and execute tests.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
